### PR TITLE
Fix local network permission dialogue appearance [APP-211] [PLAN-530]

### DIFF
--- a/ios/LocalNetworkPrivacy/LocalNetworkPrivacy.m
+++ b/ios/LocalNetworkPrivacy/LocalNetworkPrivacy.m
@@ -30,7 +30,7 @@
     self.service.delegate = self;
     [self.service publish];
 
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:2 repeats:NO block:^(NSTimer * _Nonnull timer) {
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:1 repeats:NO block:^(NSTimer * _Nonnull timer) {
         [self.timer invalidate];
         self.completion(NO);
     }];

--- a/ios/LocalNetworkPrivacy/RNPermissionHandlerLocalNetworkPrivacy.m
+++ b/ios/LocalNetworkPrivacy/RNPermissionHandlerLocalNetworkPrivacy.m
@@ -22,14 +22,18 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+  LocalNetworkPrivacy *local = [LocalNetworkPrivacy new];
   if (![RNPermissionsHelper isFlaggedAsRequested:[[self class] handlerUniqueId]]) {
+      // This will trigger the local network permission native dialog
+      [local checkAccessState:^(BOOL granted) {
+          // Ignoring result for the first time. We just want iOS to initiate the permission request
+      }];
       [RNPermissionsHelper flagAsRequested:[[self class] handlerUniqueId]];
+
+      // We can't get the permission dialog result, therefor returning not determined status
       return resolve(RNPermissionStatusNotDetermined);
   }
-    
-  [RNPermissionsHelper flagAsRequested:[[self class] handlerUniqueId]];
 
-  LocalNetworkPrivacy *local = [LocalNetworkPrivacy new];
   [local checkAccessState:^(BOOL granted) {
       resolve(granted ? RNPermissionStatusAuthorized : RNPermissionStatusDenied);
   }];


### PR DESCRIPTION
# What was changed?

- Trigger iOS system dialog when user requests for  local permission for the first time
- Ignore `LocalNetworkPrivacy.checkAccessState` result for the first time
- Remove unnecessary logic from `LocalNetworkPrivacy` file

# Checklist:

- [x] Title of the PR contains ticket link as [APP-XXX], [PLAN-XXX] 
- [x] I've ran `yarn lint` to validate code style. (`yarn lint:fix` to automatically fix issues)
- [x] I have performed a self-review of my code in Pull Request
- [x] I've checked Android and iOS platforms, attached screenshots/videos for UI changes
- [x] I squashed commits after review before merging my ticket and rebased to fix conflicts ([first squash with interactive rebase then rebase on top and fix conflicts then git push --force-with-lease](https://www.loom.com/share/b98a534574c642b3ace78646b07f7375))

# Related
 - https://planitar.atlassian.net/browse/PLAN-530
 - https://planitar.atlassian.net/browse/APP-190